### PR TITLE
Manifolds improvements

### DIFF
--- a/src/main/java/fr/radi3nt/physics/collision/CollisionData.java
+++ b/src/main/java/fr/radi3nt/physics/collision/CollisionData.java
@@ -1,18 +1,21 @@
 package fr.radi3nt.physics.collision;
 
+import fr.radi3nt.physics.collision.contact.manifold.PersistentManifold;
 import fr.radi3nt.physics.collision.shape.CollisionShape;
 import fr.radi3nt.physics.collision.shape.pre.PreCollisionShape;
 import fr.radi3nt.physics.collision.shape.provider.CollisionShapeProvider;
 import fr.radi3nt.physics.collision.shape.provider.SetCollisionShapeProvider;
-import fr.radi3nt.physics.core.TransformedObject;
 import fr.radi3nt.physics.core.state.RigidBody;
 
-import java.util.Optional;
+import java.util.ArrayList;
+import java.util.Collection;
 
 public class CollisionData implements CollisionShapeGroup {
 
     private final CollisionShapeProvider collisionShapeProvider;
     private final PreCollisionShape preCollisionShape;
+
+    private final Collection<PersistentManifold> currentCollisions = new ArrayList<>();
 
     public CollisionData(CollisionShape collisionShape) {
         this.collisionShapeProvider = new SetCollisionShapeProvider(collisionShape);
@@ -39,5 +42,9 @@ public class CollisionData implements CollisionShapeGroup {
 
     public PreCollisionShape getPreCollisionShape() {
         return preCollisionShape;
+    }
+
+    public Collection<PersistentManifold> getCurrentCollisions() {
+        return currentCollisions;
     }
 }

--- a/src/main/java/fr/radi3nt/physics/collision/contact/ContactKeyPair.java
+++ b/src/main/java/fr/radi3nt/physics/collision/contact/ContactKeyPair.java
@@ -1,0 +1,39 @@
+package fr.radi3nt.physics.collision.contact;
+
+import fr.radi3nt.physics.collision.shape.CollisionShape;
+
+import java.util.Objects;
+
+public class ContactKeyPair {
+
+    private final int bodyA;
+    private final int bodyB;
+
+    public final CollisionShape shapeA;
+    public final CollisionShape shapeB;
+
+    public ContactKeyPair(int bodyA, int bodyB, CollisionShape shapeA, CollisionShape shapeB) {
+        this.bodyA = bodyA;
+        this.bodyB = bodyB;
+        this.shapeA = shapeA;
+        this.shapeB = shapeB;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ContactKeyPair)) return false;
+
+        ContactKeyPair that = (ContactKeyPair) o;
+        return bodyA == that.bodyA && bodyB == that.bodyB && Objects.equals(shapeA, that.shapeA) && Objects.equals(shapeB, that.shapeB);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = bodyA;
+        result = 31 * result + bodyB;
+        result = 31 * result + Objects.hashCode(shapeA);
+        result = 31 * result + Objects.hashCode(shapeB);
+        return result;
+    }
+}

--- a/src/main/java/fr/radi3nt/physics/collision/contact/GeneratedContactPair.java
+++ b/src/main/java/fr/radi3nt/physics/collision/contact/GeneratedContactPair.java
@@ -1,31 +1,35 @@
 package fr.radi3nt.physics.collision.contact;
 
-import fr.radi3nt.physics.collision.CollisionShapeGroup;
 import fr.radi3nt.physics.collision.shape.CollisionShape;
-import fr.radi3nt.physics.core.TransformedObject;
+import fr.radi3nt.physics.core.state.RigidBody;
 
 import java.util.Objects;
 
-public class ContactPair {
+public class GeneratedContactPair {
 
-    public final TransformedObject objectA;
+    public final RigidBody objectA;
+    public final RigidBody objectB;
+
     public final CollisionShape shapeA;
-    public final TransformedObject objectB;
     public final CollisionShape shapeB;
 
-    public ContactPair(TransformedObject objectA, CollisionShape shapeA, TransformedObject objectB, CollisionShape shapeB) {
+    public GeneratedContactPair(RigidBody objectA, CollisionShape shapeA, RigidBody objectB, CollisionShape shapeB) {
         this.objectA = objectA;
         this.shapeA = shapeA;
         this.objectB = objectB;
         this.shapeB = shapeB;
     }
 
+    public ContactKeyPair toPair() {
+        return new ContactKeyPair(objectA.getRigidBodyId(), objectB.getRigidBodyId(), shapeA, shapeB);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof ContactPair)) return false;
+        if (!(o instanceof GeneratedContactPair)) return false;
 
-        ContactPair that = (ContactPair) o;
+        GeneratedContactPair that = (GeneratedContactPair) o;
 
         if (!Objects.equals(objectA, that.objectA)) return false;
         if (!Objects.equals(shapeA, that.shapeA)) return false;

--- a/src/main/java/fr/radi3nt/physics/collision/contact/cache/ContactPairCache.java
+++ b/src/main/java/fr/radi3nt/physics/collision/contact/cache/ContactPairCache.java
@@ -1,15 +1,13 @@
 package fr.radi3nt.physics.collision.contact.cache;
 
-import fr.radi3nt.physics.collision.contact.ContactPair;
+import fr.radi3nt.physics.collision.contact.GeneratedContactPair;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.ListIterator;
 
-public interface ContactPairCache extends Iterable<ContactPair> {
+public interface ContactPairCache extends Iterable<GeneratedContactPair> {
     void remove(int index);
-    ContactPair[] collection();
-    ListIterator<ContactPair> iterator();
+    GeneratedContactPair[] collection();
+    ListIterator<GeneratedContactPair> iterator();
 
     int size();
 }

--- a/src/main/java/fr/radi3nt/physics/collision/contact/cache/HashPersistentManifoldCache.java
+++ b/src/main/java/fr/radi3nt/physics/collision/contact/cache/HashPersistentManifoldCache.java
@@ -1,6 +1,7 @@
 package fr.radi3nt.physics.collision.contact.cache;
 
-import fr.radi3nt.physics.collision.contact.ContactPair;
+import fr.radi3nt.physics.collision.contact.ContactKeyPair;
+import fr.radi3nt.physics.collision.contact.GeneratedContactPair;
 import fr.radi3nt.physics.collision.contact.manifold.PersistentManifold;
 
 import java.util.*;
@@ -8,43 +9,52 @@ import java.util.*;
 public class HashPersistentManifoldCache implements PersistentManifoldCache {
 
     private static final int RELEVANT_STEP_DISCARD = 60;
-    private final Map<ContactPair, PersistentManifold> persistentManifoldMap = new HashMap<>();
+    private final Map<ContactKeyPair, PersistentManifold> persistentManifoldMap = new HashMap<>();
 
     private long currentStep;
 
     @Override
-    public Optional<PersistentManifold> getCachedManifold(ContactPair contactPair) {
-        PersistentManifold manifold = persistentManifoldMap.get(contactPair);
+    public Optional<PersistentManifold> getCachedManifold(GeneratedContactPair contactPair) {
+        PersistentManifold manifold = persistentManifoldMap.get(contactPair.toPair());
         if (manifold!=null)
             manifold.setRelevant(currentStep);
         return Optional.ofNullable(manifold);
     }
 
     @Override
-    public PersistentManifold newManifold(ContactPair contactPair) {
-        PersistentManifold persistentManifold = persistentManifoldMap.computeIfAbsent(contactPair, PersistentManifold::new);
+    public PersistentManifold newManifold(GeneratedContactPair contactPair) {
+        PersistentManifold persistentManifold = persistentManifoldMap.computeIfAbsent(contactPair.toPair(), keyPair -> createManifold(contactPair));
         persistentManifold.setRelevant(currentStep);
         return persistentManifold;
     }
 
+    private PersistentManifold createManifold(GeneratedContactPair contactPair) {
+        PersistentManifold persistentManifold = new PersistentManifold(contactPair.toPair());
+        contactPair.objectA.getCollisionData().getCurrentCollisions().add(persistentManifold);
+        contactPair.objectB.getCollisionData().getCurrentCollisions().add(persistentManifold);
+        return persistentManifold;
+    }
+
     @Override
-    public void releaseManifold(ContactPair pair) {
-        persistentManifoldMap.remove(pair);
+    public void releaseManifold(GeneratedContactPair pair) {
+        PersistentManifold removed = persistentManifoldMap.remove(pair.toPair());
+        if (removed!=null)
+            removedManifold(removed);
+    }
+
+    private void removedManifold(PersistentManifold removed) {
+        removed.getObjectA().getCollisionData().getCurrentCollisions().remove(removed);
+        removed.getObjectB().getCollisionData().getCurrentCollisions().remove(removed);
     }
 
     public void cleanup(long step) {
-        Iterator<Map.Entry<ContactPair, PersistentManifold>> iterator = persistentManifoldMap.entrySet().iterator();
+        Iterator<Map.Entry<ContactKeyPair, PersistentManifold>> iterator = persistentManifoldMap.entrySet().iterator();
         while (iterator.hasNext()) {
-            Map.Entry<ContactPair, PersistentManifold> next = iterator.next();
+            Map.Entry<ContactKeyPair, PersistentManifold> next = iterator.next();
             if (!next.getValue().isRelevant(step, RELEVANT_STEP_DISCARD)) {
+                removedManifold(next.getValue());
                 iterator.remove();
-                continue;
-            }
-            /*
-            next.getValue().removeInvalidPoints();
-            if (next.getValue().getManifoldPoints().isEmpty())
-                iterator.remove();
-             */
+                }
         }
     }
 

--- a/src/main/java/fr/radi3nt/physics/collision/contact/cache/ListContactPairCache.java
+++ b/src/main/java/fr/radi3nt/physics/collision/contact/cache/ListContactPairCache.java
@@ -1,22 +1,24 @@
 package fr.radi3nt.physics.collision.contact.cache;
 
-import fr.radi3nt.physics.collision.contact.ContactPair;
+import fr.radi3nt.physics.collision.contact.GeneratedContactPair;
 import fr.radi3nt.physics.collision.detection.gen.generator.PairGenerator;
 import fr.radi3nt.physics.core.state.RigidBody;
 import fr.radi3nt.physics.dynamics.island.RigidBodyIsland;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
 
 public class ListContactPairCache implements ContactPairCache {
 
-    private final List<ContactPair> contactPairs;
+    private final List<GeneratedContactPair> contactPairs;
 
-    public ListContactPairCache(List<ContactPair> contactPairs) {
+    public ListContactPairCache(List<GeneratedContactPair> contactPairs) {
         this.contactPairs = contactPairs;
     }
 
     public static ListContactPairCache fromIsland(RigidBodyIsland rigidBodyIsland, PairGenerator pairGenerator) {
-        List<ContactPair> pairs = new ArrayList<>();
+        List<GeneratedContactPair> pairs = new ArrayList<>();
         for (int i = 0; i < rigidBodyIsland.getSize(); i++) {
             for (int j = 0; j < rigidBodyIsland.getSize(); j++) {
                 if (i>j) {
@@ -37,12 +39,12 @@ public class ListContactPairCache implements ContactPairCache {
     }
 
     @Override
-    public ContactPair[] collection() {
-        return contactPairs.toArray(new ContactPair[0]);
+    public GeneratedContactPair[] collection() {
+        return contactPairs.toArray(new GeneratedContactPair[0]);
     }
 
     @Override
-    public ListIterator<ContactPair> iterator() {
+    public ListIterator<GeneratedContactPair> iterator() {
         return contactPairs.listIterator();
     }
 

--- a/src/main/java/fr/radi3nt/physics/collision/contact/cache/PersistentManifoldCache.java
+++ b/src/main/java/fr/radi3nt/physics/collision/contact/cache/PersistentManifoldCache.java
@@ -1,14 +1,14 @@
 package fr.radi3nt.physics.collision.contact.cache;
 
-import fr.radi3nt.physics.collision.contact.ContactPair;
+import fr.radi3nt.physics.collision.contact.GeneratedContactPair;
 import fr.radi3nt.physics.collision.contact.manifold.PersistentManifold;
 
 import java.util.Optional;
 
 public interface PersistentManifoldCache {
 
-    Optional<PersistentManifold> getCachedManifold(ContactPair contactPair);
-    PersistentManifold newManifold(ContactPair contactPair);
-    void releaseManifold(ContactPair pair);
+    Optional<PersistentManifold> getCachedManifold(GeneratedContactPair contactPair);
+    PersistentManifold newManifold(GeneratedContactPair contactPair);
+    void releaseManifold(GeneratedContactPair pair);
 
 }

--- a/src/main/java/fr/radi3nt/physics/collision/contact/manifold/PersistentManifold.java
+++ b/src/main/java/fr/radi3nt/physics/collision/contact/manifold/PersistentManifold.java
@@ -1,97 +1,156 @@
 package fr.radi3nt.physics.collision.contact.manifold;
 
 import fr.radi3nt.maths.components.vectors.Vector3f;
-import fr.radi3nt.maths.components.vectors.implementations.SimpleVector3f;
-import fr.radi3nt.physics.collision.contact.ContactPair;
+import fr.radi3nt.physics.collision.contact.ContactKeyPair;
+import fr.radi3nt.physics.collision.contact.GeneratedContactPair;
 import fr.radi3nt.physics.collision.contact.manifold.contact.ContactPoint;
-import fr.radi3nt.physics.core.TransformedObject;
 import fr.radi3nt.physics.core.state.DynamicsData;
+import fr.radi3nt.physics.core.state.RigidBody;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-
-import static java.lang.Math.abs;
 
 public class PersistentManifold {
 
-    private TransformedObject objectA;
-    private TransformedObject objectB;
+    private static final int MAX_CONTACT_POINTS = 4;
+    private static final float CONTACT_BREAK_THRESHOLD = 1e-2f;
+
     private final List<ManifoldPoint> manifoldPoints = new ArrayList<>();
+    private final ContactKeyPair keyPair;
     private long relevantStep;
 
-    private final Vector3f contactNormal = new SimpleVector3f();
-    private float distanceThreshold;
+    private GeneratedContactPair currentPair;
 
-    public PersistentManifold(ContactPair contactPair) {
-        this.objectA = contactPair.objectA;
-        this.objectB = contactPair.objectB;
+    public PersistentManifold(ContactKeyPair keyPair) {
+        this.keyPair = keyPair;
     }
 
-    public void setPair(TransformedObject a, TransformedObject b) {
-        objectA = a;
-        objectB = b;
-    }
+    public void refresh(RigidBody a, RigidBody b) {
+        currentPair = new GeneratedContactPair(a, keyPair.shapeA, b, keyPair.shapeB);
 
-    public void refresh() {
-        for (ManifoldPoint manifoldPoint : manifoldPoints) {
-            manifoldPoint.refresh(objectA, objectB, contactNormal);
-        }
-    }
-
-    public void removeInvalidPoints() {
-        for (int i = 0; i < manifoldPoints.size(); i++) {
+        for (int i = 0, manifoldPointsSize = manifoldPoints.size(); i < manifoldPointsSize; i++) {
             ManifoldPoint manifoldPoint = manifoldPoints.get(i);
-            boolean signedDist = manifoldPoint.exceedSignedProjectedDistanceThreshold(2);
-            if (signedDist || manifoldPoint.orthogonalDistanceExceedThreshold(2)) {
+            manifoldPoint.refresh(a, b);
+
+            if (shouldRemove(manifoldPoint)) {
                 manifoldPoints.remove(manifoldPoint);
                 i--;
+                manifoldPointsSize--;
             }
         }
     }
 
-    public void setDistanceThreshold(float distanceThreshold) {
-        this.distanceThreshold = distanceThreshold;
+    private static boolean shouldRemove(ManifoldPoint manifoldPoint) {
+        return breaksSignedThreshold(manifoldPoint) || (manifoldPoint.orthogonalDistanceExceedThreshold(CONTACT_BREAK_THRESHOLD));
+    }
+
+    private static boolean breaksSignedThreshold(ManifoldPoint manifoldPoint) {
+        return manifoldPoint.exceedSignedProjectedDistanceThreshold(CONTACT_BREAK_THRESHOLD);
     }
 
     public ContactPoint[] getContactPoints(DynamicsData a, DynamicsData b) {
         List<ContactPoint> contactPoints = new ArrayList<>();
         for (ManifoldPoint manifoldPoint : manifoldPoints) {
-            if (manifoldPoint.enabled)
-                contactPoints.add(new ContactPoint(manifoldPoint, contactNormal, manifoldPoint.getDirectionFromCenterOfMassToPointA(objectA), manifoldPoint.getDirectionFromCenterOfMassToPointB(objectB), a, b));
+            contactPoints.add(new ContactPoint(manifoldPoint, manifoldPoint.normalFromAToB.duplicate(), manifoldPoint.getDirectionFromCenterOfMassToPointA(a), manifoldPoint.getDirectionFromCenterOfMassToPointB(b), a, b));
         }
         return contactPoints.toArray(new ContactPoint[0]);
     }
 
-    public Vector3f getContactNormal() {
-        return contactNormal;
+
+    public void addManifoldPoints(Collection<ManifoldPoint> points) {
+        for (ManifoldPoint point : points) {
+            addManifoldPoint(point);
+        }
     }
 
-    public void setNormal(Vector3f contactNormal) {
-        this.contactNormal.copy(contactNormal);
+    public void addManifoldPoint(ManifoldPoint point) {
+        point.refresh(getObjectA(), getObjectB());
+
+        if (breaksSignedThreshold(point)) {
+            return;
+        }
+
+        if (manifoldPoints.size()<MAX_CONTACT_POINTS) {
+            manifoldPoints.add(point);
+            return;
+        }
+
+        int replacingIndex = findReplacingIndex(point);
+        if (replacingIndex==-1)
+            return;
+        manifoldPoints.set(replacingIndex, point);
     }
 
-    public TransformedObject getObjectA() {
-        return objectA;
+    private int findReplacingIndex(ManifoldPoint point) {
+        int shallowestIndex = findShallowestIndex(point);
+
+        float maxCurrentArea = 0;
+        int maxIndex = -1;
+
+        for (int currentIndex = 0; currentIndex < manifoldPoints.size(); currentIndex++) {
+            if (currentIndex==shallowestIndex) {
+                continue;
+            }
+
+            float currentArea = calc3PointsAreaSquared(point.localSpaceAPoint, manifoldPoints.get(currentIndex%(manifoldPoints.size()-1)).localSpaceAPoint, manifoldPoints.get((currentIndex+1)%(manifoldPoints.size()-1)).localSpaceAPoint);
+            if (currentArea > maxCurrentArea) {
+                maxCurrentArea = currentArea;
+                maxIndex = currentIndex;
+            }
+        }
+
+        return maxIndex;
     }
 
-    public TransformedObject getObjectB() {
-        return objectB;
+    private int findShallowestIndex(ManifoldPoint point) {
+        float maxPenetration = point.projectedDistance;
+        int replacingIndex = -1;
+        for (int i = 0, manifoldPointsSize = manifoldPoints.size(); i < manifoldPointsSize; i++) {
+            ManifoldPoint manifoldPoint = manifoldPoints.get(i);
+            if (manifoldPoint.projectedDistance < maxPenetration) {
+                replacingIndex = i;
+                maxPenetration = manifoldPoint.projectedDistance;
+            }
+        }
+        return replacingIndex;
+    }
+
+
+    private float calc3PointsAreaSquared(Vector3f point1, Vector3f point2, Vector3f point3) {
+        Vector3f a0 = point1.duplicate().sub(point2);
+        Vector3f b0 = point3.duplicate().sub(point2);
+        Vector3f cross = a0.cross(b0);
+        return cross.lengthSquared();
+    }
+
+    public ContactPoint[] getCurrentContactPoints() {
+        return getContactPoints(currentPair.objectA.getDynamicsData(), currentPair.objectB.getDynamicsData());
+    }
+
+    public RigidBody getObjectA() {
+        return currentPair.objectA;
+    }
+
+
+    public RigidBody getObjectB() {
+        return currentPair.objectB;
     }
 
     public List<ManifoldPoint> getManifoldPoints() {
         return manifoldPoints;
     }
 
+    public void clear() {
+        manifoldPoints.clear();
+    }
+
     public boolean isEmpty() {
-        for (ManifoldPoint manifoldPoint : manifoldPoints) {
-            if (manifoldPoint.enabled)
-                return false;
-        }
-        return true;
+        return manifoldPoints.isEmpty();
     }
 
     public boolean isRelevant(long step, int stepThreshold) {
-        return abs(this.relevantStep-step)<=stepThreshold;
+        return step-this.relevantStep<=stepThreshold;
     }
 
     public PersistentManifold setRelevant(long currentStep) {

--- a/src/main/java/fr/radi3nt/physics/collision/detection/gen/generator/BroadphaseOrderingPairGenerator.java
+++ b/src/main/java/fr/radi3nt/physics/collision/detection/gen/generator/BroadphaseOrderingPairGenerator.java
@@ -1,17 +1,12 @@
 package fr.radi3nt.physics.collision.detection.gen.generator;
 
-import fr.radi3nt.physics.collision.contact.ContactPair;
-import fr.radi3nt.physics.collision.detection.broad.aabb.CachingAABB;
+import fr.radi3nt.physics.collision.contact.GeneratedContactPair;
 import fr.radi3nt.physics.collision.shape.CollisionShape;
 import fr.radi3nt.physics.collision.shape.pre.PreCollisionPair;
-import fr.radi3nt.physics.collision.shape.pre.PreCollisionShape;
 import fr.radi3nt.physics.core.state.RigidBody;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
 public class BroadphaseOrderingPairGenerator implements PairGenerator {
@@ -24,8 +19,7 @@ public class BroadphaseOrderingPairGenerator implements PairGenerator {
     }
 
     @Override
-    public void pair(List<ContactPair> pairList, RigidBody a, RigidBody b) {
-        if ((a.getSleepingData().isSleeping() || a.getDynamicsData().getBodyProperties().inverseMass==0) && (b.getSleepingData().isSleeping()  || b.getDynamicsData().getBodyProperties().inverseMass==0))
+    public void pair(List<GeneratedContactPair> pairList, RigidBody a, RigidBody b) {
         if (a.canIgnoreCollisionDetection() && b.canIgnoreCollisionDetection())
             return;
 
@@ -43,7 +37,7 @@ public class BroadphaseOrderingPairGenerator implements PairGenerator {
         }
     }
 
-    private static ContactPair getContactPairs(RigidBody rigidBodyA, RigidBody rigidBodyB, CollisionShape a, CollisionShape b) {
+    private static GeneratedContactPair getContactPairs(RigidBody rigidBodyA, RigidBody rigidBodyB, CollisionShape a, CollisionShape b) {
         int compare = rigidBodyComparator.compare(rigidBodyA, rigidBodyB);
         if (compare < 0) {
             CollisionShape cacheShape = a;
@@ -54,6 +48,6 @@ public class BroadphaseOrderingPairGenerator implements PairGenerator {
             rigidBodyB = cacheRigidBody;
         }
 
-        return new ContactPair(rigidBodyA, a, rigidBodyB, b);
+        return new GeneratedContactPair(rigidBodyA, a, rigidBodyB, b);
     }
 }

--- a/src/main/java/fr/radi3nt/physics/collision/detection/gen/generator/PairGenerator.java
+++ b/src/main/java/fr/radi3nt/physics/collision/detection/gen/generator/PairGenerator.java
@@ -1,12 +1,12 @@
 package fr.radi3nt.physics.collision.detection.gen.generator;
 
-import fr.radi3nt.physics.collision.contact.ContactPair;
+import fr.radi3nt.physics.collision.contact.GeneratedContactPair;
 import fr.radi3nt.physics.core.state.RigidBody;
 
 import java.util.List;
 
 public interface PairGenerator {
 
-    void pair(List<ContactPair> pairList, RigidBody a, RigidBody b);
+    void pair(List<GeneratedContactPair> pairList, RigidBody a, RigidBody b);
 
 }

--- a/src/main/java/fr/radi3nt/physics/collision/detection/gen/tools/OneDimensionPairMeeter.java
+++ b/src/main/java/fr/radi3nt/physics/collision/detection/gen/tools/OneDimensionPairMeeter.java
@@ -1,18 +1,16 @@
 package fr.radi3nt.physics.collision.detection.gen.tools;
 
-import fr.radi3nt.physics.collision.contact.ContactPair;
+import fr.radi3nt.physics.collision.contact.GeneratedContactPair;
 import fr.radi3nt.physics.collision.detection.gen.generator.PairGenerator;
 import fr.radi3nt.physics.core.state.RigidBody;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
 public class OneDimensionPairMeeter {
 
     private final List<RigidBody> activeList = new ArrayList<>();
-    private final List<ContactPair> pairs = new ArrayList<>();
+    private final List<GeneratedContactPair> pairs = new ArrayList<>();
 
     private final PairGenerator pairGenerator;
     public OneDimensionPairMeeter(PairGenerator pairGenerator) {
@@ -39,7 +37,7 @@ public class OneDimensionPairMeeter {
         }
     }
 
-    public List<ContactPair> getPairs() {
+    public List<GeneratedContactPair> getPairs() {
         return pairs;
     }
 }

--- a/src/main/java/fr/radi3nt/physics/collision/detection/narrow/NarrowPhaseDetectionAlgorithm.java
+++ b/src/main/java/fr/radi3nt/physics/collision/detection/narrow/NarrowPhaseDetectionAlgorithm.java
@@ -1,6 +1,6 @@
 package fr.radi3nt.physics.collision.detection.narrow;
 
-import fr.radi3nt.physics.collision.contact.ContactPair;
+import fr.radi3nt.physics.collision.contact.GeneratedContactPair;
 import fr.radi3nt.physics.collision.contact.cache.PersistentManifoldCache;
 import fr.radi3nt.physics.collision.contact.manifold.PersistentManifold;
 
@@ -8,6 +8,6 @@ import java.util.Optional;
 
 public interface NarrowPhaseDetectionAlgorithm {
 
-    Optional<PersistentManifold> buildManifolds(PersistentManifoldCache manifoldCache, ContactPair pairs);
+    Optional<PersistentManifold> buildManifolds(PersistentManifoldCache manifoldCache, GeneratedContactPair pairs);
 
 }

--- a/src/main/java/fr/radi3nt/physics/collision/detection/narrow/dispacher/CollisionDispatcher.java
+++ b/src/main/java/fr/radi3nt/physics/collision/detection/narrow/dispacher/CollisionDispatcher.java
@@ -1,6 +1,6 @@
 package fr.radi3nt.physics.collision.detection.narrow.dispacher;
 
-import fr.radi3nt.physics.collision.contact.ContactPair;
+import fr.radi3nt.physics.collision.contact.GeneratedContactPair;
 import fr.radi3nt.physics.collision.contact.cache.PersistentManifoldCache;
 import fr.radi3nt.physics.collision.contact.manifold.PersistentManifold;
 
@@ -8,6 +8,6 @@ import java.util.Optional;
 
 public interface CollisionDispatcher {
 
-    Optional<PersistentManifold> dispatch(PersistentManifoldCache manifoldCache, ContactPair pair);
+    Optional<PersistentManifold> dispatch(PersistentManifoldCache manifoldCache, GeneratedContactPair pair);
 
 }

--- a/src/main/java/fr/radi3nt/physics/collision/detection/narrow/dispacher/SetCollisionDispatcher.java
+++ b/src/main/java/fr/radi3nt/physics/collision/detection/narrow/dispacher/SetCollisionDispatcher.java
@@ -1,10 +1,9 @@
 package fr.radi3nt.physics.collision.detection.narrow.dispacher;
 
-import fr.radi3nt.physics.collision.contact.ContactPair;
+import fr.radi3nt.physics.collision.contact.GeneratedContactPair;
 import fr.radi3nt.physics.collision.contact.cache.PersistentManifoldCache;
 import fr.radi3nt.physics.collision.contact.manifold.PersistentManifold;
 import fr.radi3nt.physics.collision.detection.narrow.NarrowPhaseDetectionAlgorithm;
-import fr.radi3nt.physics.collision.response.CollisionContactSolver;
 
 import java.util.Optional;
 
@@ -17,7 +16,7 @@ public class SetCollisionDispatcher implements CollisionDispatcher {
     }
 
     @Override
-    public Optional<PersistentManifold> dispatch(PersistentManifoldCache manifoldCache, ContactPair pair) {
+    public Optional<PersistentManifold> dispatch(PersistentManifoldCache manifoldCache, GeneratedContactPair pair) {
         return detectionAlgorithm.buildManifolds(manifoldCache, pair);
     }
 }

--- a/src/main/java/fr/radi3nt/physics/collision/detection/narrow/sat/SATNarrowPhaseDetectionAlgorithm.java
+++ b/src/main/java/fr/radi3nt/physics/collision/detection/narrow/sat/SATNarrowPhaseDetectionAlgorithm.java
@@ -1,6 +1,6 @@
 package fr.radi3nt.physics.collision.detection.narrow.sat;
 
-import fr.radi3nt.physics.collision.contact.ContactPair;
+import fr.radi3nt.physics.collision.contact.GeneratedContactPair;
 import fr.radi3nt.physics.collision.contact.cache.PersistentManifoldCache;
 import fr.radi3nt.physics.collision.contact.manifold.PersistentManifold;
 import fr.radi3nt.physics.collision.detection.narrow.NarrowPhaseDetectionAlgorithm;
@@ -12,8 +12,6 @@ import java.util.Optional;
 
 public class SATNarrowPhaseDetectionAlgorithm implements NarrowPhaseDetectionAlgorithm {
 
-    //private final CollisionGenerator generator = new CombiningCollisionGenerator(PENETRATION_EPSILON);
-    //private final CollisionGenerator generator = new RelativeCollisionGenerator(PENETRATION_EPSILON);
     private final CollisionGenerator generator = new NormalCollisionGenerator();
     private final SatManifoldComputer manifoldComputer;
 
@@ -22,7 +20,7 @@ public class SATNarrowPhaseDetectionAlgorithm implements NarrowPhaseDetectionAlg
     }
 
     @Override
-    public Optional<PersistentManifold> buildManifolds(PersistentManifoldCache manifoldCache, ContactPair pair) {
+    public Optional<PersistentManifold> buildManifolds(PersistentManifoldCache manifoldCache, GeneratedContactPair pair) {
         CollisionResult collision = generator.test(pair);
 
         if (!collision.isCollision()) {

--- a/src/main/java/fr/radi3nt/physics/collision/detection/narrow/sat/computer/CollisionGenerator.java
+++ b/src/main/java/fr/radi3nt/physics/collision/detection/narrow/sat/computer/CollisionGenerator.java
@@ -1,11 +1,9 @@
 package fr.radi3nt.physics.collision.detection.narrow.sat.computer;
 
-import fr.radi3nt.physics.collision.contact.ContactPair;
-import fr.radi3nt.physics.collision.detection.narrow.sat.computer.part.CollisionDetector;
-import fr.radi3nt.physics.collision.detection.narrow.sat.computer.part.ManifoldPointBuilder;
+import fr.radi3nt.physics.collision.contact.GeneratedContactPair;
 
 public interface CollisionGenerator {
 
-    CollisionResult test(ContactPair contactPair);
+    CollisionResult test(GeneratedContactPair contactPair);
 
 }

--- a/src/main/java/fr/radi3nt/physics/collision/detection/narrow/sat/computer/part/CollisionDetector.java
+++ b/src/main/java/fr/radi3nt/physics/collision/detection/narrow/sat/computer/part/CollisionDetector.java
@@ -1,12 +1,12 @@
 package fr.radi3nt.physics.collision.detection.narrow.sat.computer.part;
 
 import fr.radi3nt.maths.components.vectors.Vector3f;
-import fr.radi3nt.physics.collision.contact.ContactPair;
+import fr.radi3nt.physics.collision.contact.GeneratedContactPair;
 import fr.radi3nt.physics.collision.shape.sat.shape.SatShapeObject;
 
 public interface CollisionDetector {
 
-    boolean testCollision(ContactPair pair, SatShapeObject sa, SatShapeObject sb);
+    boolean testCollision(GeneratedContactPair pair, SatShapeObject sa, SatShapeObject sb);
 
     Vector3f getMinimumTranslationAxis();
 

--- a/src/main/java/fr/radi3nt/physics/collision/detection/narrow/sat/computer/part/ShapedPair.java
+++ b/src/main/java/fr/radi3nt/physics/collision/detection/narrow/sat/computer/part/ShapedPair.java
@@ -1,15 +1,15 @@
 package fr.radi3nt.physics.collision.detection.narrow.sat.computer.part;
 
-import fr.radi3nt.physics.collision.contact.ContactPair;
+import fr.radi3nt.physics.collision.contact.GeneratedContactPair;
 import fr.radi3nt.physics.collision.shape.sat.shape.SatShapeObject;
 
 public class ShapedPair {
 
-    public final ContactPair contactPair;
+    public final GeneratedContactPair contactPair;
     public final SatShapeObject sA;
     public final SatShapeObject sB;
 
-    public ShapedPair(ContactPair contactPair, SatShapeObject sA, SatShapeObject sB) {
+    public ShapedPair(GeneratedContactPair contactPair, SatShapeObject sA, SatShapeObject sB) {
         this.contactPair = contactPair;
         this.sA = sA;
         this.sB = sB;

--- a/src/main/java/fr/radi3nt/physics/collision/detection/narrow/sat/computer/part/normal/NormalCollisionGenerator.java
+++ b/src/main/java/fr/radi3nt/physics/collision/detection/narrow/sat/computer/part/normal/NormalCollisionGenerator.java
@@ -1,14 +1,12 @@
 package fr.radi3nt.physics.collision.detection.narrow.sat.computer.part.normal;
 
-import fr.radi3nt.physics.collision.contact.ContactPair;
+import fr.radi3nt.physics.collision.contact.GeneratedContactPair;
 import fr.radi3nt.physics.collision.detection.narrow.sat.computer.CollisionGenerator;
 import fr.radi3nt.physics.collision.detection.narrow.sat.computer.CollisionResult;
 import fr.radi3nt.physics.collision.detection.narrow.sat.computer.part.NoCollisionResult;
 import fr.radi3nt.physics.collision.detection.narrow.sat.computer.part.ShapedPair;
 import fr.radi3nt.physics.collision.shape.sat.SatCollisionShape;
 import fr.radi3nt.physics.collision.shape.sat.shape.SatShapeObject;
-
-import java.util.Arrays;
 
 public class NormalCollisionGenerator implements CollisionGenerator {
 
@@ -20,7 +18,7 @@ public class NormalCollisionGenerator implements CollisionGenerator {
     }
 
     @Override
-    public CollisionResult test(ContactPair contactPair) {
+    public CollisionResult test(GeneratedContactPair contactPair) {
         SatCollisionShape aShape = (SatCollisionShape) contactPair.shapeA;
         SatCollisionShape bShape = (SatCollisionShape) contactPair.shapeB;
 


### PR DESCRIPTION
## Improved manifold lifecycle and features
`PersistentManifold` have a limited number of contact points, chosen to be the deepest and the ones that cover the most area.  
Stale `ManifoldPoint` are automatically removed by the `PersistentManifold.refresh()` method.  

Added a list containing the current contact manifolds of the rigidbody in `CollisionData`